### PR TITLE
Add complex groupings and cancel accent

### DIFF
--- a/src/lexicon.js
+++ b/src/lexicon.js
@@ -326,13 +326,14 @@ Object.defineProperty(fonts, "regexp", {
 // =======
 
 const accents = {
-  hat: "^",
-  bar: "‾",
-  ul: "_",
-  vec: "→",
-  dot: "⋅",
-  ddot: "⋅⋅",
-  tilde: "˜"
+  hat: {type: "over", accent: "^"},
+  bar: {type: "over", accent: "‾"},
+  ul: {type: "under", accent: "_"},
+  vec: {type: "over", accent: "→"},
+  dot: {type: "over", accent: "⋅"},
+  ddot: {type: "over", accent: "⋅⋅"},
+  tilde: {type: "over", accent: "˜"},
+  cancel: {type: "enclose", attrs: {notation: "updiagonalstrike"}}
 };
 
 Object.defineProperty(accents, "contains", {

--- a/src/lexicon.js
+++ b/src/lexicon.js
@@ -253,7 +253,13 @@ function regexpEscape(str) {
 
 const groupings = {
   open: { "(:": "⟨", "{:": "" },
-  close: { ":)": "⟩", ":}": "" }
+  close: { ":)": "⟩", ":}": "" },
+  complex: {
+    abs: {open: "|", close: "|"},
+    floor: {open: "⌊", close: "⌋"},
+    ceil: {open: "⌈", close: "⌉"},
+    norm: {open: "∥", close: "∥"}
+  }
 };
 
 Object.defineProperty(groupings.open, "regexp", {
@@ -278,8 +284,19 @@ Object.defineProperty(groupings.close, "get", {
   }
 });
 
+Object.defineProperty(groupings.complex, "contains", {
+  value: function(str) {
+    return Object.keys(groupings.complex).indexOf(str) >= 0;
+  }
+});
+
+Object.defineProperty(groupings.complex, "get", {
+  value: function(str) { return groupings.complex[str]; }
+});
+
 Object.freeze(groupings.open);
 Object.freeze(groupings.close);
+Object.freeze(groupings.complex);
 
 
 // Font

--- a/src/parser.js
+++ b/src/parser.js
@@ -216,6 +216,17 @@ function parser(options) {
                               split.font && {mathvariant: split.font});
       rest = split.rest;
 
+    } else if (groupings.complex.contains(nextsymbol)) {
+
+      // ## Complex groupings ##
+
+      let grouping = groupings.complex.get(nextsymbol),
+          next = ascii.slice(nextsymbol.length).trimLeft(),
+          split = parseone(next);
+
+      el = mfenced(removeSurroundingBrackets(split[0]), grouping);
+      rest = split[1];
+
     } else if (syntax.isgroupStart(ascii) || syntax.isvertGroupStart(ascii)) {
 
       // ## Groupings ##

--- a/test/test.js
+++ b/test/test.js
@@ -487,6 +487,18 @@ describe('Groupings', function() {
     test('(: V(t)^2 :) = lim_(T->oo) 1/T int_(-T./2)^(T./2) V(t)^2 dt',
          '<math><mfenced open="⟨" close="⟩"><mrow><mi>V</mi><msup><mfenced open="(" close=")"><mi>t</mi></mfenced><mn>2</mn></msup></mrow></mfenced><mo>=</mo><munder><mi>lim</mi><mrow><mi>T</mi><mo>→</mo><mi mathvariant="normal">∞</mi></mrow></munder><mfrac><mn>1</mn><mi>T</mi></mfrac><msubsup><mo>∫</mo><mrow><mo>-</mo><mfrac bevelled="true"><mi>T</mi><mn>2</mn></mfrac></mrow><mfrac bevelled="true"><mi>T</mi><mn>2</mn></mfrac></msubsup><mi>V</mi><msup><mfenced open="(" close=")"><mi>t</mi></mfenced><mn>2</mn></msup><mi>d</mi><mi>t</mi></math>');
   });
+
+  it('Complex groupings', function() {
+    test('abs(x)', '<math><mfenced open="|" close="|"><mi>x</mi></mfenced></math>');
+    test('floor(x)', '<math><mfenced open="⌊" close="⌋"><mi>x</mi></mfenced></math>');
+    test('ceil(x)', '<math><mfenced open="⌈" close="⌉"><mi>x</mi></mfenced></math>');
+    test('norm(x)', '<math><mfenced open="∥" close="∥"><mi>x</mi></mfenced></math>');
+
+    test('abs x', '<math><mfenced open="|" close="|"><mi>x</mi></mfenced></math>');
+    test('floor x', '<math><mfenced open="⌊" close="⌋"><mi>x</mi></mfenced></math>');
+    test('ceil x', '<math><mfenced open="⌈" close="⌉"><mi>x</mi></mfenced></math>');
+    test('norm x', '<math><mfenced open="∥" close="∥"><mi>x</mi></mfenced></math>');
+  });
 });
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -720,6 +720,7 @@ describe('Accents', function() {
     test('dot x', '<math><mover><mi>x</mi><mo accent="true">⋅</mo></mover></math>');
     test('ddot x', '<math><mover><mi>x</mi><mo accent="true">⋅⋅</mo></mover></math>');
     test('tilde x', '<math><mover><mi>x</mi><mo accent="true">˜</mo></mover></math>');
+    test('cancel x', '<math><menclose notation="updiagonalstrike"><mi>x</mi></menclose></math>');
   });
   it('Should display dottless i and dottless j under overscript accents', function() {
     test('bar i', '<math><mover><mi>ı</mi><mo accent="true">‾</mo></mover></math>');


### PR DESCRIPTION
See #10.

The `color` accent would have been more ... complex (ha!) to implement because it has two arguments, so I skipped that one for now. If two arguments were possible, it would be as simple as defining another `enclose` accent with a `mathcolor` attribute.