### PR TITLE
Don’t make group open start a matrix when followed by a semicolon

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "ascii2mathml": "bin/index.js"
   },
   "scripts": {
-    "babelify": "babel src/ -d lib/ && babel < index.es6.js > index.js",
+    "babelify": "babel src/ -d lib/ && babel index.es6.js > index.js",
     "browserify": "(echo \"/*! ${npm_package_name} v${npm_package_version} | (c) 2015 (MIT) | ${npm_package_homepage} */\" && browserify ./index.es6.js -s ascii2mathml) > dist/ascii2mathml.js",
     "minify": "uglifyjs dist/ascii2mathml.js -b beautify=false,ascii_only=true -c -m --preamble \"/*! ${npm_package_name} v${npm_package_version} | (c) 2015 (MIT) | ${npm_package_homepage} */\" > dist/ascii2mathml.min.js",
     "lint": "eslint index.es6.js src/",

--- a/src/parser.js
+++ b/src/parser.js
@@ -253,7 +253,9 @@ function parser(options) {
         return lines.length > 1 ? lines : rowsplit(group);
       }());
 
-      if (syntax.ismatrixInterior(group.trim(), options.colSep)) {
+      if (syntax.ismatrixInterior(group.trim(),
+                                  options.colSep,
+                                  options.rowSep)) {
 
         // ### Matrix ##
 

--- a/src/syntax.js
+++ b/src/syntax.js
@@ -22,12 +22,33 @@ function isgroupable(str, options) {
   return str.match(re);
 }
 
-function ismatrixInterior(str, colSep) {
-  return isgroupStart(str) && (function() {
-    let rest = splitNextGroup(str)[4];
-    return rest.trim().startsWith(colSep) ||
-      rest.match(/^\s*\n/) && isgroupStart(rest.trim());
-  }());
+function ismatrixInterior(str, colSep, rowSep) {
+  if (!isgroupStart(str)) {
+    return false;
+  }
+
+  let rest = splitNextGroup(str)[4];
+
+  if (
+    !(rest.trim().startsWith(colSep) ||
+      rest.match(/^\s*\n/) &&
+      isgroupStart(rest.trim()))
+  ) {
+    return false;
+  }
+
+  // Make sure we are building the matrix with parenthesis, as opposed
+  // to rowSeps.
+  while (rest && rest.trim()) {
+    rest = (splitNextGroup(rest) || [])[4];
+
+    if (rest && (rest.startsWith(rowSep) || rest.match(/^\s*\n/))) {
+      // `rowSep` delimited matrices are handled elsewhere.
+      return false;
+    }
+  }
+
+  return true;
 }
 
 const funcEndingRe = new RegExp(

--- a/test/test.js
+++ b/test/test.js
@@ -649,6 +649,14 @@ describe('Matrices', function() {
       .to.be(ascii2mathml('(4; 6)'));
   });
 
+  it('Should allow comma/semicolon to take precedence over bracket delimited matrices', function() {
+    test('[(a), (b); (c), (d)]', '<math><mfenced open="[" close="]"><mtable><mtr><mtd><mfenced open="(" close=")"><mi>a</mi></mfenced></mtd><mtd><mfenced open="(" close=")"><mi>b</mi></mfenced></mtd></mtr><mtr><mtd><mfenced open="(" close=")"><mi>c</mi></mfenced></mtd><mtd><mfenced open="(" close=")"><mi>d</mi></mfenced></mtd></mtr></mtable></mfenced></math>');
+  });
+
+  it('Should allow newlines to take precedence over bracket delimited matrices', function() {
+    test('[(a), (b)\n (c), (d)]', '<math><mfenced open="[" close="]"><mtable><mtr><mtd><mfenced open="(" close=")"><mi>a</mi></mfenced></mtd><mtd><mfenced open="(" close=")"><mi>b</mi></mfenced></mtd></mtr><mtr><mtd><mfenced open="(" close=")"><mi>c</mi></mfenced></mtd><mtd><mfenced open="(" close=")"><mi>d</mi></mfenced></mtd></mtr></mtable></mfenced></math>');
+  });
+
   it('Should display vertical bar delimited matrices', function() {
     test('|(a,b,c), (d,e,f), (h,i,j)|', '<math><mfenced open="|" close="|"><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd><mtd><mi>c</mi></mtd></mtr><mtr><mtd><mi>d</mi></mtd><mtd><mi>e</mi></mtd><mtd><mi>f</mi></mtd></mtr><mtr><mtd><mi>h</mi></mtd><mtd><mi>i</mi></mtd><mtd><mi>j</mi></mtd></mtr></mtable></mfenced></math>');
   });


### PR DESCRIPTION
The two matrix syntaxes—comma/semicolon vs. paren/comma—were clashing
with each other when trying to build semicolon delimited matrix when
the first cell was a singleton fence.

This fix also applies to newline delimited matrices.

Fixes: #16